### PR TITLE
Use std::numeric_limits<uint32_t>::max() instead of UINT32_MAX.

### DIFF
--- a/src/base/config.h
+++ b/src/base/config.h
@@ -33,7 +33,7 @@
 #endif
 
 #if !defined(GID_MAX)
-#define GID_MAX  std::numeric_limits<uint32_t>::max()
+#define GID_MAX std::numeric_limits<uint32_t>::max()
 #endif
 
 namespace s3

--- a/src/base/config.h
+++ b/src/base/config.h
@@ -29,11 +29,11 @@
 #include <string>
 
 #if !defined(UID_MAX)
-#define UID_MAX UINT32_MAX
+#define UID_MAX std::numeric_limits<uint32_t>::max()
 #endif
 
 #if !defined(GID_MAX)
-#define GID_MAX UINT32_MAX
+#define GID_MAX  std::numeric_limits<uint32_t>::max()
 #endif
 
 namespace s3


### PR DESCRIPTION
I was having issues compiling with:

../../src/base/config.inc:65.1 error:  'UINT32_MAX' was not declared in this scope. 

The above fix seems to fix it , seems to be an issue seen in another project:
see: https://github.com/assimp/assimp/issues/471

Using gcc : 4.7.2  